### PR TITLE
Add DeactivatedStake reward type

### DIFF
--- a/pb/last_generate.txt
+++ b/pb/last_generate.txt
@@ -1,3 +1,3 @@
-generate.sh - Fri Jan 30 08:16:47 EST 2026 - stepd
-streamingfast/proto revision: 727b66617f7a4b9692aa98b0d68e0c8c8eec5ad8
-streamingfast/firehose-solana/proto revision: 3587429
+generate.sh - Wed Jun  3 15:05:21 EDT 2026 - stepd
+streamingfast/proto revision: 0122b19ece0716f44cdc63370a346e4d0592b262
+streamingfast/firehose-solana/proto revision: 665a24e

--- a/pb/sf/solana/type/v1/type.pb.go
+++ b/pb/sf/solana/type/v1/type.pb.go
@@ -25,11 +25,12 @@ const (
 type RewardType int32
 
 const (
-	RewardType_Unspecified RewardType = 0
-	RewardType_Fee         RewardType = 1
-	RewardType_Rent        RewardType = 2
-	RewardType_Staking     RewardType = 3
-	RewardType_Voting      RewardType = 4
+	RewardType_Unspecified      RewardType = 0
+	RewardType_Fee              RewardType = 1
+	RewardType_Rent             RewardType = 2
+	RewardType_Staking          RewardType = 3
+	RewardType_Voting           RewardType = 4
+	RewardType_DeactivatedStake RewardType = 5
 )
 
 // Enum value maps for RewardType.
@@ -40,13 +41,15 @@ var (
 		2: "Rent",
 		3: "Staking",
 		4: "Voting",
+		5: "DeactivatedStake",
 	}
 	RewardType_value = map[string]int32{
-		"Unspecified": 0,
-		"Fee":         1,
-		"Rent":        2,
-		"Staking":     3,
-		"Voting":      4,
+		"Unspecified":      0,
+		"Fee":              1,
+		"Rent":             2,
+		"Staking":          3,
+		"Voting":           4,
+		"DeactivatedStake": 5,
 	}
 )
 
@@ -1382,7 +1385,7 @@ const file_sf_solana_type_v1_type_proto_rawDesc = "" +
 	"\rUnixTimestamp\x12\x1c\n" +
 	"\ttimestamp\x18\x01 \x01(\x03R\ttimestamp\"0\n" +
 	"\vBlockHeight\x12!\n" +
-	"\fblock_height\x18\x01 \x01(\x04R\vblockHeight*I\n" +
+	"\fblock_height\x18\x01 \x01(\x04R\vblockHeight*_\n" +
 	"\n" +
 	"RewardType\x12\x0f\n" +
 	"\vUnspecified\x10\x00\x12\a\n" +
@@ -1390,7 +1393,8 @@ const file_sf_solana_type_v1_type_proto_rawDesc = "" +
 	"\x04Rent\x10\x02\x12\v\n" +
 	"\aStaking\x10\x03\x12\n" +
 	"\n" +
-	"\x06Voting\x10\x04BEZCgithub.com/streamingfast/firehose-solana/pb/sf/solana/type/v1;pbsolb\x06proto3"
+	"\x06Voting\x10\x04\x12\x14\n" +
+	"\x10DeactivatedStake\x10\x05BEZCgithub.com/streamingfast/firehose-solana/pb/sf/solana/type/v1;pbsolb\x06proto3"
 
 var (
 	file_sf_solana_type_v1_type_proto_rawDescOnce sync.Once

--- a/proto/sf/solana/type/v1/type.proto
+++ b/proto/sf/solana/type/v1/type.proto
@@ -133,6 +133,7 @@ enum RewardType {
   Rent = 2;
   Staking = 3;
   Voting = 4;
+  DeactivatedStake = 5;
 }
 
 message Reward {


### PR DESCRIPTION
## What

Adds the `DeactivatedStake = 5` variant to the `sf.solana.type.v1.RewardType` enum and regenerates the Go bindings.

## Why

Solana (agave 4.x, via `solana-reward-info` 6.2.0) introduced a new `RewardType::DeactivatedStake` variant. Without a matching value in the firehose proto, reward data of this type cannot be represented and gets mapped to `Unspecified`, losing information.

## Compatibility

Appending a new enum value is a wire-compatible, non-breaking change:
- The field tag and encoding of existing values (`Fee`/`Rent`/`Staking`/`Voting`) are untouched.
- Existing consumers keep decoding unchanged; they treat `5` as an unknown value (default enum) until they regenerate against the updated schema.

Generated `type.pb.go` was refreshed via `pb/generate.sh` (only the new value + alignment whitespace changed; no generator-version churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)